### PR TITLE
Add Nix flake for ibosh CLI installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,205 @@
+# Contributing to instant-bosh
+
+Thank you for your interest in contributing to instant-bosh! This guide will help you get started with development.
+
+## Development Setup
+
+### Prerequisites
+
+You can use either Nix or devbox for development:
+
+#### Using Nix Flakes
+
+```bash
+# Enter development shell
+nix develop
+
+# Or use direnv for automatic environment loading
+echo "use flake" > .envrc
+direnv allow
+```
+
+#### Using devbox
+
+```bash
+# Enter devbox shell
+devbox shell
+
+# Or use direnv for automatic environment loading (if .envrc is configured for devbox)
+direnv allow
+```
+
+## Building the Project
+
+### Building the ibosh CLI
+
+```bash
+# Using devbox
+devbox run build-ibosh
+
+# Or using make
+make build-ibosh
+
+# Or directly with go
+go build -o ibosh ./cmd/ibosh
+```
+
+### Building the BOSH OCI Image
+
+The BOSH director runs as an OCI image. To build it:
+
+```bash
+make build
+```
+
+This uses [bob (BOSH OCI Builder)](https://github.com/rkoster/bosh-oci-builder) to create the director image with all necessary configurations.
+
+For development with a local version of bob:
+
+```bash
+make dev-bob-build
+```
+
+## Available Makefile Targets
+
+### Build Targets
+
+- `make build` - Build BOSH OCI image using bob
+- `make build-ibosh` - Build the ibosh CLI binary
+- `make dev-bob-build` - Build BOSH OCI image using go run (for bob development)
+
+### Runtime Targets
+
+- `make run` - Run the built BOSH image using docker run (deprecated: use `ibosh start` instead)
+- `make stop` - Stop the running BOSH container (deprecated: use `ibosh stop` instead)
+- `make logs` - Show logs from the running BOSH container
+- `make print-env` - Print environment variables for BOSH CLI (use: `eval "$(make print-env)"`)
+
+### Maintenance Targets
+
+- `make sync` - Sync vendored dependencies using vendir
+- `make clean` - Stop container and remove image (keeps volumes)
+- `make reset` - Full reset: stop container, remove volumes and image
+- `make help` - Show available targets
+
+## Running Tests
+
+This project uses [Ginkgo](https://onsi.github.io/ginkgo/) for testing:
+
+```bash
+# Run all tests
+go run github.com/onsi/ginkgo/v2/ginkgo -r
+
+# Run tests with verbose output
+go run github.com/onsi/ginkgo/v2/ginkgo -r -v
+```
+
+## Development Workflow
+
+### 1. Sync Dependencies
+
+When updating vendored BOSH deployment manifests:
+
+```bash
+make sync
+```
+
+This uses [vendir](https://carvel.dev/vendir/) to sync dependencies defined in `vendir.yml`.
+
+### 2. Make Code Changes
+
+Make your changes to the Go code in:
+- `cmd/ibosh/` - CLI entry point
+- `internal/` - Internal packages
+
+### 3. Test Your Changes
+
+```bash
+# Run tests
+go run github.com/onsi/ginkgo/v2/ginkgo -r
+
+# Build and test the CLI
+make build-ibosh
+./ibosh help
+```
+
+### 4. Build and Test the Director Image
+
+```bash
+# Build the director image
+make build
+
+# Start the director
+ibosh start
+
+# Test functionality
+ibosh status
+eval "$(ibosh print-env)"
+bosh env
+
+# Clean up
+ibosh destroy
+```
+
+## Project Structure
+
+```
+.
+├── cmd/ibosh/          # CLI entry point
+├── internal/           # Internal packages
+│   ├── commands/       # CLI command implementations
+│   ├── director/       # BOSH director client
+│   ├── docker/         # Docker client wrapper
+│   ├── logparser/      # Log parsing utilities
+│   └── logwriter/      # Log writing utilities
+├── ops/                # Ops files for BOSH director customization
+├── test/               # Test fixtures and manifests
+├── vendor/             # Vendored BOSH deployment manifests
+├── Makefile           # Build automation
+├── vendir.yml         # Dependency configuration
+├── devbox.json        # Devbox configuration
+└── flake.nix          # Nix flake configuration
+```
+
+## Code Style
+
+- Follow standard Go conventions
+- Run `gofmt` before committing
+- Write tests for new functionality
+- Update documentation for user-facing changes
+
+## Debugging
+
+### Debug Template Rendering
+
+To debug BOSH template rendering without running hooks:
+
+```bash
+make debug
+```
+
+### View Container Logs
+
+```bash
+# Using ibosh
+ibosh logs
+
+# Using make
+make logs
+
+# Using docker directly
+docker logs instant-bosh
+```
+
+## Release Process
+
+1. Update version numbers (if applicable)
+2. Build and test locally
+3. Create a pull request
+4. After merge, the CI/CD pipeline will build and publish the image
+
+## Getting Help
+
+- Open an issue on GitHub for bugs or feature requests
+- Check existing issues for known problems
+- Review the README.md for user documentation

--- a/README.md
+++ b/README.md
@@ -10,17 +10,35 @@ A containerized BOSH director for local development and testing.
 - SSH support for VMs (via runtime-config)
 - Jumpbox user for proxying SSH connections
 
+## Installation
+
+### Using Nix Flakes
+
+The easiest way to install instant-bosh is using Nix flakes:
+
+```bash
+# Install directly from GitHub
+nix profile install github:rkoster/instant-bosh
+
+# Or run without installing
+nix run github:rkoster/instant-bosh -- help
+
+# Or add to your flake.nix inputs
+inputs.instant-bosh.url = "github:rkoster/instant-bosh";
+```
+
+### Building from Source
+
+If you want to build from source, see [CONTRIBUTING.md](CONTRIBUTING.md) for development setup instructions.
+
 ## Quick Start
 
 ```bash
-# Build the BOSH director image
-make build
-
 # Start the director using ibosh CLI
 ibosh start
 
 # Set BOSH CLI environment variables
-eval "$(make print-env)"
+eval "$(ibosh print-env)"
 
 # Verify BOSH is running
 bosh env
@@ -39,24 +57,31 @@ ibosh destroy
 
 ### ibosh CLI Commands
 
-The `ibosh` CLI provides a streamlined interface for managing instant-bosh:
+```
+NAME:
+   ibosh - instant-bosh CLI
 
-- `ibosh start` - Start the instant-bosh director (creates volumes, network, and container; auto-pulls image if not available)
-- `ibosh stop` - Stop the running director
-- `ibosh status` - Show status of instant-bosh and containers on the network
-- `ibosh destroy` - Remove all instant-bosh resources (container, volumes, network, and network containers)
-- `ibosh pull` - Pull the latest instant-bosh image from the registry
-- `ibosh logs` - Show logs from the instant-bosh container (use `-f` to follow, `-n` to specify number of lines)
+USAGE:
+   ibosh [global options] command [command options]
 
-### Available Makefile Targets
+COMMANDS:
+   start      Start instant-bosh director
+   stop       Stop instant-bosh director
+   destroy    Destroy instant-bosh director and all data
+   status     Show status of instant-bosh and containers on the network
+   pull       Pull latest instant-bosh image
+   print-env  Print environment variables for BOSH CLI
+   logs       Show logs from the instant-bosh container
+   help, h    Shows a list of commands or help for one command
 
-- `make build` - Build BOSH OCI image using bob
-- `make logs` - Show director logs
-- `make print-env` - Print BOSH CLI environment variables
+GLOBAL OPTIONS:
+   --debug, -d  Enable debug logging (default: false)
+   --help, -h   show help
+```
 
 ### Deploying Workloads
 
-After running `make run` and setting the environment with `eval "$(make print-env)"`, you can deploy BOSH releases:
+After starting instant-bosh with `ibosh start` and setting the environment with `eval "$(ibosh print-env)"`, you can deploy BOSH releases:
 
 ```bash
 # Deploy a sample zookeeper cluster
@@ -85,7 +110,7 @@ Since systemd services don't auto-start in Docker containers, SSH must be explic
 1. **os-conf-release**: Provides the `pre-start-script` job
 2. **Runtime Config** (`runtime-config-enable-vm-ssh.yml`): Applies the SSH startup script to all VMs
 
-The `make run` target automatically:
+The `ibosh start` command automatically:
 - Uploads the `os-conf-release`
 - Applies the runtime config
 - Configures cloud-config
@@ -102,22 +127,8 @@ This allows `bosh ssh` to work seamlessly with VMs running as Docker containers.
 
 ## Development
 
-### Running Tests
+For information on contributing to instant-bosh, building from source, running tests, and understanding the project structure, please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-This project uses [Ginkgo](https://onsi.github.io/ginkgo/) for testing:
+## License
 
-```bash
-# Run all tests
-go run github.com/onsi/ginkgo/v2/ginkgo -r
-
-# Run tests with verbose output
-go run github.com/onsi/ginkgo/v2/ginkgo -r -v
-```
-
-## Files
-
-- `Makefile` - Build and run automation
-- `runtime-config-enable-vm-ssh.yml` - Runtime config to enable SSH on VMs
-- `ops-*.yml` - Ops files for customizing the BOSH director
-- `vendor/bosh-deployment/` - Vendored BOSH deployment manifests
-- `test/manifest/` - Example deployment manifests
+This project is licensed under the Business Source License 1.1 - see the [LICENSE](LICENSE) file for details.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1764517877,
+        "narHash": "sha256-pp3uT4hHijIC8JUK5MEqeAWmParJrgBVzHLNfJDZxg4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2d293cbfa5a793b4c50d17c05ef9e385b90edf6c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,73 @@
+{
+  description = "instant-bosh - A containerized BOSH director for local development and testing";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages = {
+          default = self.packages.${system}.ibosh;
+          
+          ibosh = pkgs.buildGoModule {
+            pname = "ibosh";
+            version = "0.1.0";
+            
+            src = pkgs.lib.cleanSourceWith {
+              src = ./.;
+              filter = path: type:
+                let baseName = baseNameOf path;
+                in baseName != "vendor" && baseName != ".git";
+            };
+            
+            vendorHash = "sha256-3GPvp9OFpIzTm/BtuWy+sUnuhFc/2QOZ4WO7eh24nqY=";
+            
+            subPackages = [ "cmd/ibosh" ];
+            
+            ldflags = [ "-s" "-w" ];
+            
+            # Install shell completions
+            postInstall = ''
+              installShellCompletion --cmd ibosh \
+                --bash <($out/bin/ibosh --generate-bash-completion) \
+                --zsh <($out/bin/ibosh --generate-zsh-completion) \
+                --fish <($out/bin/ibosh --generate-fish-completion)
+            '';
+            
+            nativeBuildInputs = [ pkgs.installShellFiles ];
+            
+            meta = with pkgs.lib; {
+              description = "instant-bosh CLI - Manage containerized BOSH directors";
+              homepage = "https://github.com/rkoster/instant-bosh";
+              license = licenses.bsl11;
+              maintainers = [ ];
+              mainProgram = "ibosh";
+            };
+          };
+        };
+
+        # Development shell with dependencies
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            go
+          ];
+        };
+
+        # Apps for easy running
+        apps = {
+          default = self.apps.${system}.ibosh;
+          
+          ibosh = {
+            type = "app";
+            program = "${self.packages.${system}.ibosh}/bin/ibosh";
+          };
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary

This PR implements the requirements from https://github.com/rkoster/instant-bosh/issues/14 by adding Nix flake support for easy installation of the ibosh CLI and reorganizing documentation.

### Changes Made

1. **Added `flake.nix`**: Provides a Nix flake for installing the ibosh CLI
   - Users can install with `nix profile install github:rkoster/instant-bosh`
   - Users can run without installing with `nix run github:rkoster/instant-bosh`
   - Includes development shell with required dependencies
   - Properly excludes the vendir `vendor` directory from Go builds

2. **Created `CONTRIBUTING.md`**: Moved development-focused documentation from README
   - Build instructions and Makefile targets
   - Development workflow and testing
   - Project structure documentation
   - Debugging tips

3. **Updated `README.md`**: Refocused on end-users
   - Added Nix installation section
   - Updated CLI usage with current help output
   - Removed make-related content (moved to CONTRIBUTING.md)
   - Replaced `make` commands with `ibosh` commands throughout
   - Added License section

### Installation Methods

After this PR, users can install ibosh in multiple ways:

```bash
# Using Nix flakes (new, easiest)
nix profile install github:rkoster/instant-bosh

# Using Nix flakes (run without installing)
nix run github:rkoster/instant-bosh -- help

# Building from source (see CONTRIBUTING.md)
```

### Testing

- Built and tested the flake successfully
- Verified ibosh CLI binary works correctly
- Confirmed all documentation is accurate

Fixes https://github.com/rkoster/instant-bosh/issues/14