### PR TITLE
fix: correct devbox command syntax in auto-bump workflow

### DIFF
--- a/.github/workflows/auto-bump.yml
+++ b/.github/workflows/auto-bump.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run vendir sync
         run: |
-          devbox shell -- vendir sync
+          devbox run -- vendir sync
 
       - name: Check for changes
         id: check_changes


### PR DESCRIPTION
## Summary

This PR fixes the auto-bump workflow that was failing with the error:
```
Error: unknown command "vendir" for "devbox shell"
```

## Root Cause

The workflow was using `devbox shell -- vendir sync`, but `devbox shell` is designed to spawn an interactive shell session, not to run commands directly. This caused the error because devbox was trying to interpret "vendir" as a subcommand of `devbox shell`.

## Solution

Changed the command from:
```bash
devbox shell -- vendir sync
```

to:
```bash
devbox run -- vendir sync
```

The `devbox run` command is the correct way to execute commands within the devbox environment. It:
1. Sets up the environment with all packages from `devbox.json` (including vendir)
2. Runs the specified command
3. Exits when the command completes

## Testing

This change aligns with the PR review feedback that mentioned using `devbox run -- vendir sync` for testing. The workflow should now successfully:
1. Run `vendir sync` within the devbox environment
2. Detect any dependency changes
3. Generate appropriate commit messages
4. Push updates to the main branch

## Related Issues

Fixes https://github.com/rkoster/rubionic-workspace/issues/164