### PR TITLE
Fix Docker tag generation causing build failures

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -49,7 +49,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix={{branch}}-
+            type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Install Nix


### PR DESCRIPTION
## Summary

- Fixes invalid Docker tag generation that was causing build failures
- Removes problematic `{{branch}}-` prefix from SHA tags that resulted in malformed tags like `-991697f`

## Problem

The build workflow was failing with this error:
```
error parsing reference: "ghcr.io/rkoster/instant-bosh:-991697f" is not a valid repository/tag: invalid reference format
```

This occurred because the `docker/metadata-action` configuration had:
```yaml
type=sha,prefix={{branch}}-
```

When the `{{branch}}` variable was empty or not available, the prefix became just `-`, resulting in invalid Docker tags like `-991697f`.

## Solution

Changed the SHA tag configuration to:
```yaml
type=sha
```

This allows the metadata action to generate valid tags using its default format (e.g., `sha-991697f`) instead of the malformed tags.

## Testing

The build workflow should now successfully:
1. Generate valid Docker tags
2. Tag the built image correctly
3. Push images to the registry without errors

Fixes https://github.com/rkoster/rubionic-workspace/issues/166
Fixes https://github.com/rkoster/instant-bosh/issues/25