### PR TITLE
Remove SSH fix runtime config for Noble stemcells

### DIFF
--- a/internal/commands/embedded_configs.go
+++ b/internal/commands/embedded_configs.go
@@ -41,34 +41,9 @@ compilation:
   network: default
 `
 
-	runtimeConfigYAML = `---
-# Runtime config to enable SSH on Docker-based VMs
-# This ensures systemd starts SSH service on all VMs since it doesn't auto-start in containers
 
-releases:
-- name: os-conf
-  version: 23.0.0
-  url: https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=23.0.0
-  sha1: sha256:efcf30754ce4c5f308aedab3329d8d679f5967b2a4c3c453204c7cb10c7c5ed9
-
-addons:
-- name: enable-ssh
-  include:
-    stemcell:
-    - os: ubuntu-noble
-  jobs:
-  - name: pre-start-script
-    release: os-conf
-    properties:
-      script: |-
-        #!/bin/bash
-        set -e
-        # Start SSH service for bosh ssh to work in Docker containers
-        systemctl start ssh || true
-`
 )
 
 var (
-	cloudConfigYAMLBytes   = []byte(cloudConfigYAML)
-	runtimeConfigYAMLBytes = []byte(runtimeConfigYAML)
+	cloudConfigYAMLBytes = []byte(cloudConfigYAML)
 )

--- a/internal/commands/start.go
+++ b/internal/commands/start.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 	"time"
 
-	boshdir "github.com/cloudfoundry/bosh-cli/v7/director"
 	boshui "github.com/cloudfoundry/bosh-cli/v7/ui"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	"github.com/rkoster/instant-bosh/internal/director"
 	"github.com/rkoster/instant-bosh/internal/docker"
-	"gopkg.in/yaml.v3"
 )
 
 func StartAction(ui boshui.UI, logger boshlog.Logger) error {
@@ -98,12 +96,6 @@ func StartAction(ui boshui.UI, logger boshlog.Logger) error {
 		return fmt.Errorf("failed to apply cloud-config: %w", err)
 	}
 
-	// Apply runtime-config
-	ui.PrintLinef("Applying runtime-config...")
-	if err := applyRuntimeConfig(ctx, dockerClient, logger); err != nil {
-		return fmt.Errorf("failed to apply runtime-config: %w", err)
-	}
-
 	ui.PrintLinef("")
 	ui.PrintLinef("To configure your BOSH CLI environment, run:")
 	ui.PrintLinef("  eval \"$(ibosh print-env)\"")
@@ -111,45 +103,7 @@ func StartAction(ui boshui.UI, logger boshlog.Logger) error {
 	return nil
 }
 
-// applyConfig is a helper function to apply either cloud-config or runtime-config
-func applyConfig(ctx context.Context, dockerClient *docker.Client, logger boshlog.Logger, configType, configName string, configYAML []byte) error {
-	// Get director configuration
-	config, err := director.GetDirectorConfig(ctx, dockerClient)
-	if err != nil {
-		return fmt.Errorf("failed to get director config: %w", err)
-	}
-	defer config.Cleanup()
-
-	// Create BOSH director client
-	directorClient, err := director.NewDirector(config, logger)
-	if err != nil {
-		return fmt.Errorf("failed to create director client: %w", err)
-	}
-
-	// Update the appropriate config type
-	switch configType {
-	case "cloud":
-		if err := directorClient.UpdateCloudConfig(configName, configYAML); err != nil {
-			return fmt.Errorf("failed to update cloud-config: %w", err)
-		}
-		logger.Debug("startCommand", "Cloud-config applied successfully")
-	case "runtime":
-		if err := directorClient.UpdateRuntimeConfig(configName, configYAML); err != nil {
-			return fmt.Errorf("failed to update runtime-config: %w", err)
-		}
-		logger.Debug("startCommand", "Runtime-config applied successfully")
-	default:
-		return fmt.Errorf("unknown config type: %s", configType)
-	}
-
-	return nil
-}
-
 func applyCloudConfig(ctx context.Context, dockerClient *docker.Client, logger boshlog.Logger) error {
-	return applyConfig(ctx, dockerClient, logger, "cloud", "default", cloudConfigYAMLBytes)
-}
-
-func applyRuntimeConfig(ctx context.Context, dockerClient *docker.Client, logger boshlog.Logger) error {
 	// Get director configuration
 	config, err := director.GetDirectorConfig(ctx, dockerClient)
 	if err != nil {
@@ -163,48 +117,11 @@ func applyRuntimeConfig(ctx context.Context, dockerClient *docker.Client, logger
 		return fmt.Errorf("failed to create director client: %w", err)
 	}
 
-	// Parse runtime config to extract releases
-	var runtimeConfig struct {
-		Releases []struct {
-			Name    string `yaml:"name"`
-			Version string `yaml:"version"`
-			URL     string `yaml:"url"`
-			SHA1    string `yaml:"sha1"`
-		} `yaml:"releases"`
+	// Apply cloud-config
+	if err := directorClient.UpdateCloudConfig("default", cloudConfigYAMLBytes); err != nil {
+		return fmt.Errorf("failed to update cloud-config: %w", err)
 	}
-
-	if err := yaml.Unmarshal(runtimeConfigYAMLBytes, &runtimeConfig); err != nil {
-		return fmt.Errorf("failed to parse runtime config: %w", err)
-	}
-
-	// Upload releases before applying runtime config
-	for _, release := range runtimeConfig.Releases {
-		if release.URL != "" {
-			logger.Debug("startCommand", "Uploading release %s/%s from %s", release.Name, release.Version, release.URL)
-
-			// Check if release already exists
-			hasRelease, err := directorClient.HasRelease(release.Name, release.Version, boshdir.OSVersionSlug{})
-			if err != nil {
-				return fmt.Errorf("failed to check if release exists: %w", err)
-			}
-
-			if !hasRelease {
-				// Upload the release using the URL
-				if err := directorClient.UploadReleaseURL(release.URL, release.SHA1, false, false); err != nil {
-					return fmt.Errorf("failed to upload release %s/%s: %w", release.Name, release.Version, err)
-				}
-				logger.Debug("startCommand", "Successfully uploaded release %s/%s", release.Name, release.Version)
-			} else {
-				logger.Debug("startCommand", "Release %s/%s already exists, skipping upload", release.Name, release.Version)
-			}
-		}
-	}
-
-	// Now apply the runtime config
-	if err := directorClient.UpdateRuntimeConfig("enable-ssh", runtimeConfigYAMLBytes); err != nil {
-		return fmt.Errorf("failed to update runtime-config: %w", err)
-	}
-	logger.Debug("startCommand", "Runtime-config applied successfully")
+	logger.Debug("startCommand", "Cloud-config applied successfully")
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Testing in https://github.com/rkoster/instant-bosh/issues/24 confirmed that SSH works on Noble stemcells without the runtime config workaround. This PR removes the now-unnecessary SSH fix.

## Changes

- **Removed `runtimeConfigYAML`** constant from `embedded_configs.go` containing the enable-ssh runtime configuration
- **Removed `applyRuntimeConfig()`** function from `start.go` that uploaded os-conf-release and applied the runtime config
- **Simplified `applyCloudConfig()`** to directly apply cloud config without the generic helper function
- **Removed unused imports** (`yaml.v3` and `boshdir` packages)

## Benefits

- ✅ **Faster startup**: No longer uploads os-conf-release or applies runtime config during `ibosh start`
- ✅ **Simpler code**: Removes ~90 lines of unnecessary configuration logic
- ✅ **Fewer dependencies**: Eliminates dependency on os-conf-release
- ✅ **Works with Noble**: Confirmed SSH functionality works without workaround

## Testing

- All existing tests pass (`ginkgo -r`)
- Binary builds successfully (`devbox run build-ibosh`)
- Manual testing in https://github.com/rkoster/instant-bosh/issues/24 confirmed SSH works without runtime config

Fixes https://github.com/rkoster/rubionic-workspace/issues/167
Resolves https://github.com/rkoster/instant-bosh/issues/24