### PR TITLE
Improve UX for volume and network creation messages

### DIFF
--- a/internal/commands/start_test.go
+++ b/internal/commands/start_test.go
@@ -91,6 +91,9 @@ var _ = Describe("StartAction", func() {
 		// Default: volume creation succeeds
 		fakeDockerAPI.VolumeCreateReturns(volume.Volume{}, nil)
 
+		// Default: volumes don't exist initially
+		fakeDockerAPI.VolumeInspectReturns(volume.Volume{}, errdefs.NotFound(errors.New("not found")))
+
 		// Default: container creation succeeds
 		fakeDockerAPI.ContainerCreateReturns(container.CreateResponse{ID: "test-container-id"}, nil)
 
@@ -530,7 +533,7 @@ var _ = Describe("StartAction", func() {
 	})
 
 	Context("factory pattern implementation", func() {
-		It("successfully implements factory pattern for all dependencies", func() {
+			It("successfully implements factory pattern for all dependencies", func() {
 			// Verify all factories are properly instantiated
 			Expect(fakeClientFactory).NotTo(BeNil())
 			Expect(fakeConfigProvider).NotTo(BeNil())
@@ -549,6 +552,316 @@ var _ = Describe("StartAction", func() {
 			director, err := fakeDirectorFactory.NewDirector(config, logger)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(director).NotTo(BeNil())
+		})
+	})
+
+	Describe("resource existence checks", func() {
+		Context("when volumes and network already exist", func() {
+			BeforeEach(func() {
+				// Container list starts empty, then returns running container after start
+				fakeDockerAPI.ContainerListStub = func(ctx context.Context, options container.ListOptions) ([]types.Container, error) {
+					if fakeDockerAPI.ContainerStartCallCount() > 0 {
+						return []types.Container{
+							{
+								Names: []string{"/instant-bosh"},
+								State: "running",
+								Image: "ghcr.io/rkoster/instant-bosh:latest",
+							},
+						}, nil
+					}
+					return []types.Container{}, nil
+				}
+
+				// Volumes exist
+				fakeDockerAPI.VolumeInspectReturns(volume.Volume{
+					Name: "test-volume",
+				}, nil)
+
+				// Network exists
+				fakeDockerAPI.NetworkInspectReturns(network.Inspect{
+					Name: docker.NetworkName,
+				}, nil)
+
+				// Image exists locally
+				fakeDockerAPI.ImageInspectWithRawReturns(types.ImageInspect{
+					ID:          "sha256:local-image-id",
+					RepoDigests: []string{"ghcr.io/rkoster/instant-bosh@sha256:same123"},
+				}, nil, nil)
+
+				// Remote has same digest (at latest version)
+				fakeDockerAPI.DistributionInspectReturns(registry.DistributionInspect{
+					Descriptor: ocispec.Descriptor{
+						Digest: "sha256:same123",
+					},
+				}, nil)
+
+				// Container inspection returns healthy
+				fakeDockerAPI.ContainerInspectReturns(types.ContainerJSON{
+					ContainerJSONBase: &types.ContainerJSONBase{
+						State: &types.ContainerState{
+							Running: true,
+							Health:  &types.Health{Status: "healthy"},
+						},
+					},
+				}, nil)
+			})
+
+			It("displays 'Using existing' messages for volumes and network", func() {
+				err := commands.StartActionWithFactories(fakeUI, logger, fakeClientFactory, fakeConfigProvider, fakeDirectorFactory, false, "")
+				Expect(err).NotTo(HaveOccurred())
+
+				// Verify volumes were NOT created
+				Expect(fakeDockerAPI.VolumeCreateCallCount()).To(Equal(0))
+
+				// Verify network was NOT created
+				Expect(fakeDockerAPI.NetworkCreateCallCount()).To(Equal(0))
+
+				// Check for "Using existing" messages in UI
+				foundUsingVolumesMessage := false
+				foundUsingNetworkMessage := false
+				for i := 0; i < fakeUI.PrintLinefCallCount(); i++ {
+					format, _ := fakeUI.PrintLinefArgsForCall(i)
+					if strings.Contains(format, "Using existing volumes") {
+						foundUsingVolumesMessage = true
+					}
+					if strings.Contains(format, "Using existing network") {
+						foundUsingNetworkMessage = true
+					}
+				}
+				Expect(foundUsingVolumesMessage).To(BeTrue(), "Expected to find 'Using existing volumes' message")
+				Expect(foundUsingNetworkMessage).To(BeTrue(), "Expected to find 'Using existing network' message")
+
+				// Verify container was created and started
+				Expect(fakeDockerAPI.ContainerCreateCallCount()).To(Equal(1))
+				Expect(fakeDockerAPI.ContainerStartCallCount()).To(Equal(1))
+			})
+		})
+
+		Context("when volumes and network don't exist", func() {
+			BeforeEach(func() {
+				// Container list starts empty, then returns running container after start
+				fakeDockerAPI.ContainerListStub = func(ctx context.Context, options container.ListOptions) ([]types.Container, error) {
+					if fakeDockerAPI.ContainerStartCallCount() > 0 {
+						return []types.Container{
+							{
+								Names: []string{"/instant-bosh"},
+								State: "running",
+								Image: "ghcr.io/rkoster/instant-bosh:latest",
+							},
+						}, nil
+					}
+					return []types.Container{}, nil
+				}
+
+				// Volumes don't exist
+				fakeDockerAPI.VolumeInspectReturns(volume.Volume{}, errdefs.NotFound(errors.New("not found")))
+
+				// Network doesn't exist
+				fakeDockerAPI.NetworkInspectReturns(network.Inspect{}, errdefs.NotFound(errors.New("not found")))
+
+				// Image exists locally
+				fakeDockerAPI.ImageInspectWithRawReturns(types.ImageInspect{
+					ID:          "sha256:local-image-id",
+					RepoDigests: []string{"ghcr.io/rkoster/instant-bosh@sha256:same123"},
+				}, nil, nil)
+
+				// Remote has same digest (at latest version)
+				fakeDockerAPI.DistributionInspectReturns(registry.DistributionInspect{
+					Descriptor: ocispec.Descriptor{
+						Digest: "sha256:same123",
+					},
+				}, nil)
+
+				// Container inspection returns healthy
+				fakeDockerAPI.ContainerInspectReturns(types.ContainerJSON{
+					ContainerJSONBase: &types.ContainerJSONBase{
+						State: &types.ContainerState{
+							Running: true,
+							Health:  &types.Health{Status: "healthy"},
+						},
+					},
+				}, nil)
+			})
+
+			It("displays 'Creating' messages and creates volumes and network", func() {
+				err := commands.StartActionWithFactories(fakeUI, logger, fakeClientFactory, fakeConfigProvider, fakeDirectorFactory, false, "")
+				Expect(err).NotTo(HaveOccurred())
+
+				// Verify volumes were created
+				Expect(fakeDockerAPI.VolumeCreateCallCount()).To(Equal(2))
+
+				// Verify network was created
+				Expect(fakeDockerAPI.NetworkCreateCallCount()).To(Equal(1))
+
+				// Check for "Creating" messages in UI
+				foundCreatingVolumesMessage := false
+				foundCreatingNetworkMessage := false
+				for i := 0; i < fakeUI.PrintLinefCallCount(); i++ {
+					format, _ := fakeUI.PrintLinefArgsForCall(i)
+					if strings.Contains(format, "Creating volumes") {
+						foundCreatingVolumesMessage = true
+					}
+					if strings.Contains(format, "Creating network") {
+						foundCreatingNetworkMessage = true
+					}
+				}
+				Expect(foundCreatingVolumesMessage).To(BeTrue(), "Expected to find 'Creating volumes' message")
+				Expect(foundCreatingNetworkMessage).To(BeTrue(), "Expected to find 'Creating network' message")
+
+				// Verify container was created and started
+				Expect(fakeDockerAPI.ContainerCreateCallCount()).To(Equal(1))
+				Expect(fakeDockerAPI.ContainerStartCallCount()).To(Equal(1))
+			})
+		})
+
+		Context("when only one volume exists", func() {
+			BeforeEach(func() {
+				// Container list starts empty, then returns running container after start
+				fakeDockerAPI.ContainerListStub = func(ctx context.Context, options container.ListOptions) ([]types.Container, error) {
+					if fakeDockerAPI.ContainerStartCallCount() > 0 {
+						return []types.Container{
+							{
+								Names: []string{"/instant-bosh"},
+								State: "running",
+								Image: "ghcr.io/rkoster/instant-bosh:latest",
+							},
+						}, nil
+					}
+					return []types.Container{}, nil
+				}
+
+				// One volume exists, one doesn't
+				fakeDockerAPI.VolumeInspectStub = func(ctx context.Context, volumeID string) (volume.Volume, error) {
+					if volumeID == docker.VolumeStore {
+						return volume.Volume{Name: docker.VolumeStore}, nil
+					}
+					return volume.Volume{}, errdefs.NotFound(errors.New("not found"))
+				}
+
+				// Network exists
+				fakeDockerAPI.NetworkInspectReturns(network.Inspect{
+					Name: docker.NetworkName,
+				}, nil)
+
+				// Image exists locally
+				fakeDockerAPI.ImageInspectWithRawReturns(types.ImageInspect{
+					ID:          "sha256:local-image-id",
+					RepoDigests: []string{"ghcr.io/rkoster/instant-bosh@sha256:same123"},
+				}, nil, nil)
+
+				// Remote has same digest (at latest version)
+				fakeDockerAPI.DistributionInspectReturns(registry.DistributionInspect{
+					Descriptor: ocispec.Descriptor{
+						Digest: "sha256:same123",
+					},
+				}, nil)
+
+				// Container inspection returns healthy
+				fakeDockerAPI.ContainerInspectReturns(types.ContainerJSON{
+					ContainerJSONBase: &types.ContainerJSONBase{
+						State: &types.ContainerState{
+							Running: true,
+							Health:  &types.Health{Status: "healthy"},
+						},
+					},
+				}, nil)
+			})
+
+			It("displays 'Creating volumes' and creates only the missing volume", func() {
+				err := commands.StartActionWithFactories(fakeUI, logger, fakeClientFactory, fakeConfigProvider, fakeDirectorFactory, false, "")
+				Expect(err).NotTo(HaveOccurred())
+
+				// Verify only one volume was created (the missing one)
+				Expect(fakeDockerAPI.VolumeCreateCallCount()).To(Equal(1))
+
+				// Check for "Creating volumes" message (since at least one needs to be created)
+				foundCreatingVolumesMessage := false
+				foundUsingNetworkMessage := false
+				for i := 0; i < fakeUI.PrintLinefCallCount(); i++ {
+					format, _ := fakeUI.PrintLinefArgsForCall(i)
+					if strings.Contains(format, "Creating volumes") {
+						foundCreatingVolumesMessage = true
+					}
+					if strings.Contains(format, "Using existing network") {
+						foundUsingNetworkMessage = true
+					}
+				}
+				Expect(foundCreatingVolumesMessage).To(BeTrue(), "Expected to find 'Creating volumes' message")
+				Expect(foundUsingNetworkMessage).To(BeTrue(), "Expected to find 'Using existing network' message")
+
+				// Verify container was created and started
+				Expect(fakeDockerAPI.ContainerCreateCallCount()).To(Equal(1))
+				Expect(fakeDockerAPI.ContainerStartCallCount()).To(Equal(1))
+			})
+		})
+
+		Context("when volume inspection fails with non-NotFound error", func() {
+			BeforeEach(func() {
+				// Volumes inspection fails with unexpected error
+				fakeDockerAPI.VolumeInspectReturns(volume.Volume{}, errors.New("unexpected error"))
+
+				// Image exists locally
+				fakeDockerAPI.ImageInspectWithRawReturns(types.ImageInspect{
+					ID:          "sha256:local-image-id",
+					RepoDigests: []string{"ghcr.io/rkoster/instant-bosh@sha256:same123"},
+				}, nil, nil)
+
+				// Remote has same digest (at latest version)
+				fakeDockerAPI.DistributionInspectReturns(registry.DistributionInspect{
+					Descriptor: ocispec.Descriptor{
+						Digest: "sha256:same123",
+					},
+				}, nil)
+			})
+
+			It("fails fast and returns the error", func() {
+				err := commands.StartActionWithFactories(fakeUI, logger, fakeClientFactory, fakeConfigProvider, fakeDirectorFactory, false, "")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to check if volume"))
+
+				// Verify volumes were NOT created
+				Expect(fakeDockerAPI.VolumeCreateCallCount()).To(Equal(0))
+
+				// Verify container was NOT created
+				Expect(fakeDockerAPI.ContainerCreateCallCount()).To(Equal(0))
+			})
+		})
+
+		Context("when network inspection fails with non-NotFound error", func() {
+			BeforeEach(func() {
+				// Volumes exist
+				fakeDockerAPI.VolumeInspectReturns(volume.Volume{
+					Name: "test-volume",
+				}, nil)
+
+				// Network inspection fails with unexpected error
+				fakeDockerAPI.NetworkInspectReturns(network.Inspect{}, errors.New("unexpected error"))
+
+				// Image exists locally
+				fakeDockerAPI.ImageInspectWithRawReturns(types.ImageInspect{
+					ID:          "sha256:local-image-id",
+					RepoDigests: []string{"ghcr.io/rkoster/instant-bosh@sha256:same123"},
+				}, nil, nil)
+
+				// Remote has same digest (at latest version)
+				fakeDockerAPI.DistributionInspectReturns(registry.DistributionInspect{
+					Descriptor: ocispec.Descriptor{
+						Digest: "sha256:same123",
+					},
+				}, nil)
+			})
+
+			It("fails fast and returns the error", func() {
+				err := commands.StartActionWithFactories(fakeUI, logger, fakeClientFactory, fakeConfigProvider, fakeDirectorFactory, false, "")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to check if network exists"))
+
+				// Verify network was NOT created
+				Expect(fakeDockerAPI.NetworkCreateCallCount()).To(Equal(0))
+
+				// Verify container was NOT created
+				Expect(fakeDockerAPI.ContainerCreateCallCount()).To(Equal(0))
+			})
 		})
 	})
 })

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -224,6 +224,30 @@ func (c *Client) Close() error {
 	return c.cli.Close()
 }
 
+func (c *Client) VolumeExists(ctx context.Context, name string) (bool, error) {
+	c.logger.Debug(c.logTag, "Checking if volume %s exists", name)
+	_, err := c.cli.VolumeInspect(ctx, name)
+	if err != nil {
+		if client.IsErrNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("inspecting volume %s: %w", name, err)
+	}
+	return true, nil
+}
+
+func (c *Client) NetworkExists(ctx context.Context, name string) (bool, error) {
+	c.logger.Debug(c.logTag, "Checking if network %s exists", name)
+	_, err := c.cli.NetworkInspect(ctx, name, network.InspectOptions{})
+	if err != nil {
+		if client.IsErrNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("inspecting network %s: %w", name, err)
+	}
+	return true, nil
+}
+
 func (c *Client) CreateVolume(ctx context.Context, name string) error {
 	c.logger.Debug(c.logTag, "Creating volume %s", name)
 	_, err := c.cli.VolumeCreate(ctx, volume.CreateOptions{

--- a/internal/docker/docker_api.go
+++ b/internal/docker/docker_api.go
@@ -43,6 +43,7 @@ type DockerAPI interface {
 	// Volume operations
 	VolumeCreate(ctx context.Context, options volume.CreateOptions) (volume.Volume, error)
 	VolumeRemove(ctx context.Context, volumeID string, force bool) error
+	VolumeInspect(ctx context.Context, volumeID string) (volume.Volume, error)
 
 	// Utility methods
 	Close() error

--- a/internal/docker/dockerfakes/fake_docker_api.go
+++ b/internal/docker/dockerfakes/fake_docker_api.go
@@ -283,6 +283,20 @@ type FakeDockerAPI struct {
 		result1 volume.Volume
 		result2 error
 	}
+	VolumeInspectStub        func(context.Context, string) (volume.Volume, error)
+	volumeInspectMutex       sync.RWMutex
+	volumeInspectArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+	}
+	volumeInspectReturns struct {
+		result1 volume.Volume
+		result2 error
+	}
+	volumeInspectReturnsOnCall map[int]struct {
+		result1 volume.Volume
+		result2 error
+	}
 	VolumeRemoveStub        func(context.Context, string, bool) error
 	volumeRemoveMutex       sync.RWMutex
 	volumeRemoveArgsForCall []struct {
@@ -1511,6 +1525,71 @@ func (fake *FakeDockerAPI) VolumeCreateReturnsOnCall(i int, result1 volume.Volum
 		})
 	}
 	fake.volumeCreateReturnsOnCall[i] = struct {
+		result1 volume.Volume
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeDockerAPI) VolumeInspect(arg1 context.Context, arg2 string) (volume.Volume, error) {
+	fake.volumeInspectMutex.Lock()
+	ret, specificReturn := fake.volumeInspectReturnsOnCall[len(fake.volumeInspectArgsForCall)]
+	fake.volumeInspectArgsForCall = append(fake.volumeInspectArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.VolumeInspectStub
+	fakeReturns := fake.volumeInspectReturns
+	fake.recordInvocation("VolumeInspect", []interface{}{arg1, arg2})
+	fake.volumeInspectMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeDockerAPI) VolumeInspectCallCount() int {
+	fake.volumeInspectMutex.RLock()
+	defer fake.volumeInspectMutex.RUnlock()
+	return len(fake.volumeInspectArgsForCall)
+}
+
+func (fake *FakeDockerAPI) VolumeInspectCalls(stub func(context.Context, string) (volume.Volume, error)) {
+	fake.volumeInspectMutex.Lock()
+	defer fake.volumeInspectMutex.Unlock()
+	fake.VolumeInspectStub = stub
+}
+
+func (fake *FakeDockerAPI) VolumeInspectArgsForCall(i int) (context.Context, string) {
+	fake.volumeInspectMutex.RLock()
+	defer fake.volumeInspectMutex.RUnlock()
+	argsForCall := fake.volumeInspectArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeDockerAPI) VolumeInspectReturns(result1 volume.Volume, result2 error) {
+	fake.volumeInspectMutex.Lock()
+	defer fake.volumeInspectMutex.Unlock()
+	fake.VolumeInspectStub = nil
+	fake.volumeInspectReturns = struct {
+		result1 volume.Volume
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeDockerAPI) VolumeInspectReturnsOnCall(i int, result1 volume.Volume, result2 error) {
+	fake.volumeInspectMutex.Lock()
+	defer fake.volumeInspectMutex.Unlock()
+	fake.VolumeInspectStub = nil
+	if fake.volumeInspectReturnsOnCall == nil {
+		fake.volumeInspectReturnsOnCall = make(map[int]struct {
+			result1 volume.Volume
+			result2 error
+		})
+	}
+	fake.volumeInspectReturnsOnCall[i] = struct {
 		result1 volume.Volume
 		result2 error
 	}{result1, result2}


### PR DESCRIPTION
## Summary

This PR improves the user experience by displaying accurate messages about resource creation during `ibosh start`. Instead of always showing "Creating volumes..." and "Creating network..." even when resources already exist, the command now checks for resource existence first and displays appropriate messages.

## Changes

### 1. Added `VolumeInspect` to `DockerAPI` interface
- File: `internal/docker/docker_api.go`
- Enables checking if volumes exist before attempting creation

### 2. Added helper methods to `Client`
- File: `internal/docker/client.go`
- `VolumeExists(ctx, name)`: Checks if a volume exists, returns error for non-NotFound errors (fail fast)
- `NetworkExists(ctx, name)`: Checks if a network exists, returns error for non-NotFound errors (fail fast)

### 3. Updated `startContainer` function
- File: `internal/commands/start.go`
- Checks if both volumes exist before attempting creation
- Checks if network exists before attempting creation
- Displays grouped messages:
  - `Using existing volumes...` when both volumes exist
  - `Creating volumes...` when at least one volume needs to be created
  - `Using existing network...` when network exists
  - `Creating network...` when network needs to be created

### 4. Added comprehensive test cases
- File: `internal/commands/start_test.go`
- Tests for resources existing vs. not existing
- Tests for partial resource existence (one volume exists, one doesn't)
- Tests for error handling during inspection failures
- Tests verify appropriate messages are displayed in each scenario

### 5. Regenerated fakes
- File: `internal/docker/dockerfakes/fake_docker_api.go`
- Updated with `VolumeInspect` method

## Expected UX Outcomes

**When volumes and network already exist:**
```
Using existing volumes...
Using existing network...
Starting instant-bosh container...
```

**When volumes and network don't exist (first run):**
```
Creating volumes...
Creating network...
Starting instant-bosh container...
```

**When some exist and some don't:**
```
Creating volumes...
Using existing network...
Starting instant-bosh container...
```

## Benefits

1. **Accurate messaging** - Users see what's actually happening
2. **Reassurance** - Users know their existing data and workloads are being reused
3. **Transparency** - Clear distinction between first-time setup and subsequent starts
4. **Reliability** - Fail fast if we can't determine resource state

## Testing

- All existing tests pass
- New test cases added for resource existence scenarios
- Binary builds successfully
- Implementation follows existing code patterns

Fixes https://github.com/rkoster/instant-bosh/issues/38
Related to https://github.com/rkoster/rubionic-workspace/issues/201